### PR TITLE
Modify sly-doc-map keybindings

### DIFF
--- a/doc/sly.texi
+++ b/doc/sly.texi
@@ -817,10 +817,10 @@ in a web browser. The Hyperspec is found either on the Web or in
 Note: this is one case where @kbd{C-c C-d h} is @emph{not} the same as
 @kbd{C-c C-d C-h}.
 
-@kbditem{C-c C-d C-~, hyperspec-lookup-format}
+@kbditem{C-c C-d ~, hyperspec-lookup-format}
 Lookup a @emph{format character} in the @cite{Common Lisp Hyperspec}.
 
-@kbditem{C-c C-d C-#, hyperspec-lookup-reader-macro}
+@kbditem{C-c C-d #, hyperspec-lookup-reader-macro}
 Lookup a @emph{reader macro} in the @cite{Common Lisp Hyperspec}.
 @end table
 

--- a/sly.el
+++ b/sly.el
@@ -401,8 +401,8 @@ PROPERTIES specifies any default face properties."
     (define-key map (kbd "C-d") 'sly-describe-symbol)
     (define-key map (kbd "C-f") 'sly-describe-function)
     (define-key map (kbd "C-h") 'sly-documentation-lookup)
-    (define-key map (kbd "C-~") 'common-lisp-hyperspec-format)
-    (define-key map (kbd "C-#") 'common-lisp-hyperspec-lookup-reader-macro)
+    (define-key map (kbd "~") 'common-lisp-hyperspec-format)
+    (define-key map (kbd "#") 'common-lisp-hyperspec-lookup-reader-macro)
     map))
 
 (defvar sly-who-map


### PR DESCRIPTION
(sly.el): Remove Ctrl from sly-doc-map for common-lisp-hyperspec-format
          and common-lisp-hyperspec-lookup-reader-macro
(sly.texi): Update the documentation to reflect the new keybindings