### PR TITLE
Closes #51: make sly-quit-threas-buffer interactive

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -5824,6 +5824,7 @@ was called originally."
                (current-buffer)))))))
 
 (defun sly-quit-threads-buffer ()
+  (interactive)
   (when sly-threads-buffer-timer
     (cancel-timer sly-threads-buffer-timer))
   (quit-window t)


### PR DESCRIPTION
Make function interactive so it can be used from a key binding