### PR TITLE
When not implemented xref-* should not raise an error on the Emacs side

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -4603,6 +4603,7 @@ This is used by `sly-goto-next-xref'")
                 continuation)))
 
 (defun sly-check-xref-implemented (type xrefs)
+  "Check if xref functionality is available in the implementation."
   (when (eq xrefs :not-implemented)
     (sly-display-oneliner "%s is not implemented yet on %s."
                           (sly-xref-type type)
@@ -4610,6 +4611,7 @@ This is used by `sly-goto-next-xref'")
     t))
 
 (defun sly-xref-type (type)
+  "Return a human readable version of xref-type."
   (format "who-%s" (sly-cl-symbol-name type)))
 
 (defun sly-xref--get-xrefs (types symbol &optional continuation)

--- a/sly.el
+++ b/sly.el
@@ -4592,21 +4592,22 @@ This is used by `sly-goto-next-xref'")
   (sly-eval-async
       `(slynk:xref ',type ',symbol)
     (sly-rcurry (lambda (result type symbol package cont)
-                    (sly-check-xref-implemented type result)
-                    (let* ((_xrefs (sly-postprocess-xrefs result))
-                           (file-alist (cadr (sly-analyze-xrefs result))))
-                      (funcall (or cont 'sly-xref--show-results)
-                               file-alist type symbol package)))
-                  type
-                  symbol
-                  (sly-current-package)
-                  continuation)))
+                  (or (sly-check-xref-implemented type result)
+                      (let* ((_xrefs (sly-postprocess-xrefs result))
+                             (file-alist (cadr (sly-analyze-xrefs result))))
+                        (funcall (or cont 'sly-xref--show-results)
+                                 file-alist type symbol package))))
+                type
+                symbol
+                (sly-current-package)
+                continuation)))
 
 (defun sly-check-xref-implemented (type xrefs)
   (when (eq xrefs :not-implemented)
-    (error "%s is not implemented yet on %s."
-           (sly-xref-type type)
-           (sly-lisp-implementation-name))))
+    (sly-display-oneliner "%s is not implemented yet on %s."
+                          (sly-xref-type type)
+                          (sly-lisp-implementation-name))
+    t))
 
 (defun sly-xref-type (type)
   (format "who-%s" (sly-cl-symbol-name type)))


### PR DESCRIPTION
Btw, feel free to not use the commit itself as I did not used the async idioms used through the code, although AFAIU they are only needed when communicating with the lisp side. 