### PR TITLE
sly-sexp-at-point shouldn't search past the prompt

### DIFF
--- a/sly.el
+++ b/sly.el
@@ -7104,6 +7104,15 @@ The returned bounds are either nil or non-empty."
         (buffer-substring-no-properties (car bounds)
                                         (cdr bounds)))))
 
+(defun sly-prompt-end ()
+  "Return the point where the prompt ends."
+  (save-excursion
+    (goto-char (point-max))
+    (while (not (eq 'sly-mrepl-prompt-face
+                    (get-text-property (point) 'face)))
+      (backward-char 1))
+    (point)))
+
 (defun sly-bounds-of-sexp-at-point (&optional interactive)
   "Return the bounds sexp near point as a pair (or nil).
 With non-nil INTERACTIVE, error if can't find such a thing."
@@ -7114,7 +7123,9 @@ With non-nil INTERACTIVE, error if can't find such a thing."
            (save-restriction
              (narrow-to-region (point) (point-max))
              (bounds-of-thing-at-point 'sexp)))
-      (bounds-of-thing-at-point 'sexp)
+      (save-restriction
+        (narrow-to-region (sly-prompt-end) (point-max))
+        (bounds-of-thing-at-point 'sexp))
       (and (save-excursion
              (and (ignore-errors
                     (backward-sexp 1))


### PR DESCRIPTION
Currently if one, for example, calls sly-inspect on an empty prompt on the mrepl one gets the whole buffer as a 'suggestion' to inspect. (This happens to be quite often when I want to inspect a package). From what I can see the problem lies with the call to (thing-at-point 'sexp) in sly-bounds-of-sexp-at-point.

There are however problems with my proposed solution. (So consider it more of a bug report with extra effort)

It depends on the mrepl-contrib being loaded as I identify that a character belongs to the prompt by seeing if the 'face property is 'sly-mrepl-prompt-face. Ignoring that using `sly-mrepl--last-prompt-overlay` would probably be more appropriate, this breaks the modularity of contribs. Also the restriction, in principle should apply to the whole of sly-bounds-of-sexp-at-point.

Perhaps a better solution would be for a mechanism to mark which parts of the buffer are 'editable'?