### PR TITLE
remove lib/.nosearch

### DIFF
--- a/lib/.nosearch
+++ b/lib/.nosearch
@@ -1,1 +1,0 @@
-;; normal-top-level-add-subdirs-to-load-path needs this file


### PR DESCRIPTION
This file was originally added to prevent a bundled `cl-lib` from
ending up on the `load-path`.  But since then other libraries that
actually should be inside a directory on the `load-path' were added
and `cl-lib` was removed.

I noticed that you require sly libraries using `(require sly-X "lib/sly-X")`. After applying this you should also be able to remove the `"lib/sly-X"`.